### PR TITLE
Apply database cleanup to tests

### DIFF
--- a/exercises/03.resources/05.problem.linked/src/index.test.ts
+++ b/exercises/03.resources/05.problem.linked/src/index.test.ts
@@ -1,11 +1,16 @@
+import fs from 'node:fs/promises'
+import path from 'node:path'
 import { invariant } from '@epic-web/invariant'
 import { Client } from '@modelcontextprotocol/sdk/client/index.js'
 import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js'
 import { test, beforeAll, afterAll, expect } from 'vitest'
 
 let client: Client
+const EPIC_ME_DB_PATH = `./test.ignored/db.${process.env.VITEST_WORKER_ID}.sqlite`
 
 beforeAll(async () => {
+	const dir = path.dirname(EPIC_ME_DB_PATH)
+	await fs.mkdir(dir, { recursive: true })
 	client = new Client({
 		name: 'EpicMeTester',
 		version: '1.0.0',
@@ -13,12 +18,17 @@ beforeAll(async () => {
 	const transport = new StdioClientTransport({
 		command: 'tsx',
 		args: ['src/index.ts'],
+		env: {
+			...process.env,
+			EPIC_ME_DB_PATH,
+		},
 	})
 	await client.connect(transport)
 })
 
 afterAll(async () => {
 	await client.transport?.close()
+	await fs.unlink(EPIC_ME_DB_PATH)
 })
 
 test('Tool Definition', async () => {

--- a/exercises/03.resources/05.solution.linked/src/index.test.ts
+++ b/exercises/03.resources/05.solution.linked/src/index.test.ts
@@ -1,11 +1,16 @@
+import fs from 'node:fs/promises'
+import path from 'node:path'
 import { invariant } from '@epic-web/invariant'
 import { Client } from '@modelcontextprotocol/sdk/client/index.js'
 import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js'
 import { test, beforeAll, afterAll, expect } from 'vitest'
 
 let client: Client
+const EPIC_ME_DB_PATH = `./test.ignored/db.${process.env.VITEST_WORKER_ID}.sqlite`
 
 beforeAll(async () => {
+	const dir = path.dirname(EPIC_ME_DB_PATH)
+	await fs.mkdir(dir, { recursive: true })
 	client = new Client({
 		name: 'EpicMeTester',
 		version: '1.0.0',
@@ -13,12 +18,17 @@ beforeAll(async () => {
 	const transport = new StdioClientTransport({
 		command: 'tsx',
 		args: ['src/index.ts'],
+		env: {
+			...process.env,
+			EPIC_ME_DB_PATH,
+		},
 	})
 	await client.connect(transport)
 })
 
 afterAll(async () => {
 	await client.transport?.close()
+	await fs.unlink(EPIC_ME_DB_PATH)
 })
 
 test('Tool Definition', async () => {

--- a/exercises/03.resources/06.problem.embedded/src/index.test.ts
+++ b/exercises/03.resources/06.problem.embedded/src/index.test.ts
@@ -1,11 +1,16 @@
+import fs from 'node:fs/promises'
+import path from 'node:path'
 import { invariant } from '@epic-web/invariant'
 import { Client } from '@modelcontextprotocol/sdk/client/index.js'
 import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js'
 import { test, beforeAll, afterAll, expect } from 'vitest'
 
 let client: Client
+const EPIC_ME_DB_PATH = `./test.ignored/db.${process.env.VITEST_WORKER_ID}.sqlite`
 
 beforeAll(async () => {
+	const dir = path.dirname(EPIC_ME_DB_PATH)
+	await fs.mkdir(dir, { recursive: true })
 	client = new Client({
 		name: 'EpicMeTester',
 		version: '1.0.0',
@@ -13,12 +18,17 @@ beforeAll(async () => {
 	const transport = new StdioClientTransport({
 		command: 'tsx',
 		args: ['src/index.ts'],
+		env: {
+			...process.env,
+			EPIC_ME_DB_PATH,
+		},
 	})
 	await client.connect(transport)
 })
 
 afterAll(async () => {
 	await client.transport?.close()
+	await fs.unlink(EPIC_ME_DB_PATH)
 })
 
 test('Tool Definition', async () => {

--- a/exercises/03.resources/06.solution.embedded/src/index.test.ts
+++ b/exercises/03.resources/06.solution.embedded/src/index.test.ts
@@ -1,11 +1,16 @@
+import fs from 'node:fs/promises'
+import path from 'node:path'
 import { invariant } from '@epic-web/invariant'
 import { Client } from '@modelcontextprotocol/sdk/client/index.js'
 import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js'
 import { test, beforeAll, afterAll, expect } from 'vitest'
 
 let client: Client
+const EPIC_ME_DB_PATH = `./test.ignored/db.${process.env.VITEST_WORKER_ID}.sqlite`
 
 beforeAll(async () => {
+	const dir = path.dirname(EPIC_ME_DB_PATH)
+	await fs.mkdir(dir, { recursive: true })
 	client = new Client({
 		name: 'EpicMeTester',
 		version: '1.0.0',
@@ -13,12 +18,17 @@ beforeAll(async () => {
 	const transport = new StdioClientTransport({
 		command: 'tsx',
 		args: ['src/index.ts'],
+		env: {
+			...process.env,
+			EPIC_ME_DB_PATH,
+		},
 	})
 	await client.connect(transport)
 })
 
 afterAll(async () => {
 	await client.transport?.close()
+	await fs.unlink(EPIC_ME_DB_PATH)
 })
 
 test('Tool Definition', async () => {

--- a/exercises/04.prompts/03.problem.completion/src/index.test.ts
+++ b/exercises/04.prompts/03.problem.completion/src/index.test.ts
@@ -1,11 +1,16 @@
+import fs from 'node:fs/promises'
+import path from 'node:path'
 import { invariant } from '@epic-web/invariant'
 import { Client } from '@modelcontextprotocol/sdk/client/index.js'
 import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js'
 import { test, beforeAll, afterAll, expect } from 'vitest'
 
 let client: Client
+const EPIC_ME_DB_PATH = `./test.ignored/db.${process.env.VITEST_WORKER_ID}.sqlite`
 
 beforeAll(async () => {
+	const dir = path.dirname(EPIC_ME_DB_PATH)
+	await fs.mkdir(dir, { recursive: true })
 	client = new Client({
 		name: 'EpicMeTester',
 		version: '1.0.0',
@@ -13,12 +18,17 @@ beforeAll(async () => {
 	const transport = new StdioClientTransport({
 		command: 'tsx',
 		args: ['src/index.ts'],
+		env: {
+			...process.env,
+			EPIC_ME_DB_PATH,
+		},
 	})
 	await client.connect(transport)
 })
 
 afterAll(async () => {
 	await client.transport?.close()
+	await fs.unlink(EPIC_ME_DB_PATH)
 })
 
 test('Tool Definition', async () => {

--- a/exercises/04.prompts/03.solution.completion/src/index.test.ts
+++ b/exercises/04.prompts/03.solution.completion/src/index.test.ts
@@ -1,11 +1,16 @@
+import fs from 'node:fs/promises'
+import path from 'node:path'
 import { invariant } from '@epic-web/invariant'
 import { Client } from '@modelcontextprotocol/sdk/client/index.js'
 import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js'
 import { test, beforeAll, afterAll, expect } from 'vitest'
 
 let client: Client
+const EPIC_ME_DB_PATH = `./test.ignored/db.${process.env.VITEST_WORKER_ID}.sqlite`
 
 beforeAll(async () => {
+	const dir = path.dirname(EPIC_ME_DB_PATH)
+	await fs.mkdir(dir, { recursive: true })
 	client = new Client({
 		name: 'EpicMeTester',
 		version: '1.0.0',
@@ -13,12 +18,17 @@ beforeAll(async () => {
 	const transport = new StdioClientTransport({
 		command: 'tsx',
 		args: ['src/index.ts'],
+		env: {
+			...process.env,
+			EPIC_ME_DB_PATH,
+		},
 	})
 	await client.connect(transport)
 })
 
 afterAll(async () => {
 	await client.transport?.close()
+	await fs.unlink(EPIC_ME_DB_PATH)
 })
 
 test('Tool Definition', async () => {


### PR DESCRIPTION
Add database cleanup to `index.test.ts` files in exercises 3 and 4 to ensure test isolation and proper resource disposal.