### PR TITLE
Remove `sampling` reference from FINISHED.mdx

### DIFF
--- a/exercises/FINISHED.mdx
+++ b/exercises/FINISHED.mdx
@@ -44,8 +44,8 @@ Hooray! You're all done! 👏👏
 
 **In summary:**
 
-You've built a robust MCP server that supports tools, resources, prompts, and
-sampling. You've learned to design for extensibility, safety, and real-world use
+You've built a robust MCP server that supports tools, resources, and prompts.
+You've learned to design for extensibility, safety, and real-world use
 cases—empowering both users and language models to interact with your server in
 powerful, structured ways.
 


### PR DESCRIPTION
See https://discord.com/channels/715220730605731931/1409600399069020240/1421298667456954482 for context.

Note: the Edit this page link is broken and links to https://github.com/epicweb-dev/mcp-fundamentals/edit/main/exercises/finished.mdx/README.mdx when it should be https://github.com/epicweb-dev/mcp-fundamentals/edit/main/exercises/FINISHED.mdx