### PR TITLE
Mcp workshop update research

### DIFF
--- a/docs/upgrade-research.md
+++ b/docs/upgrade-research.md
@@ -216,7 +216,8 @@ Current draft changelog vs `2025-11-25` is small but non-zero.
 - Likely impact on this workshop if draft ships soon:
   - Update lifecycle/capabilities teaching to include optional extension
     negotiation.
-  - Ensure examples/tests do not assume a fully-closed capabilities object shape.
+  - Ensure examples/tests do not assume a fully-closed capabilities object
+    shape.
 - Preemptive action now:
   - Add one short note + snippet in the intro/lifecycle material showing
     `capabilities.extensions` as optional and forward-compatible.
@@ -231,7 +232,7 @@ Current draft changelog vs `2025-11-25` is small but non-zero.
   - Still useful to teach that `_meta` may carry tracing context and should not
     be stripped accidentally.
 - Preemptive action now:
-  - Add a brief “_meta is reserved and may include trace context” callout in
+  - Add a brief “\_meta is reserved and may include trace context” callout in
     lifecycle/protocol fundamentals.
 
 ### Draft risk level summary
@@ -318,8 +319,7 @@ Authentication / MCP-UI._
 
 ### 3) Add one-week draft hedge changes now
 
-1. Add a short lifecycle note/snippet for optional
-   `capabilities.extensions`.
+1. Add a short lifecycle note/snippet for optional `capabilities.extensions`.
 2. Add a short protocol note that `_meta` may carry trace context keys
    (`traceparent`, `tracestate`, `baggage`).
 3. Keep these as lightweight notes so if draft becomes stable quickly, this

--- a/docs/upgrade-research.md
+++ b/docs/upgrade-research.md
@@ -294,6 +294,48 @@ Authentication / MCP-UI._
 
 ---
 
+## BREAKING CHANGES (video re-record required)
+
+_Definition for this plan:_ a change is "breaking" if it requires changing
+exercise code/step solutions, or adding/removing/restructuring exercises in a
+way that invalidates current recorded walkthroughs.
+
+### Breaking changes in the current recommended update direction
+
+1. **SDK baseline upgrade to current line (`@modelcontextprotocol/sdk v1.27.1`+)**
+   - Why this is breaking: stricter spec/type behavior in newer SDK versions can
+     require edits to exercise step solutions and tests.
+   - Re-record impact: any lesson video that shows solution code or test behavior
+     affected by SDK alignment.
+
+2. **Add icons metadata examples to core primitives**
+   - Why this is breaking: solution code must change where tools/resources/
+     resource templates/prompts are registered.
+   - Re-record impact: Tools, Resources, Resource-Tools, and Prompts recordings
+     that demonstrate those solution steps.
+
+3. **Adopt stricter schema guidance in exercise solutions (if enforced)**
+   - Scope: no-arg tool schema patterns, explicit 2020-12-friendly schema
+     handling, and any test assertions enforcing those patterns.
+   - Why this is breaking: solution snippets and passing test outputs would
+     change.
+   - Re-record impact: affected exercise steps where schemas are taught or
+     validated.
+
+4. **Any exercise inventory change (add/remove/reorder exercises or steps)**
+   - Why this is breaking: existing video sequence no longer matches learner
+     navigation and expected diffs.
+   - Re-record impact: all recordings touching modified flow segments.
+
+### Not breaking (no re-record required by itself)
+
+- Spec URL/version link updates only.
+- Instruction wording/policy updates only (including "no backwards compatibility"
+  posture text).
+- Draft watchlist and planning notes that do not alter exercise code.
+
+---
+
 ## Recommended actions to take (clear checklist)
 
 ### 1) Lock decisions now (non-negotiable)

--- a/docs/upgrade-research.md
+++ b/docs/upgrade-research.md
@@ -1,0 +1,270 @@
+# MCP Upgrade Research (Fundamentals Workshop)
+
+_Last updated: 2026-02-26_
+
+## Goal
+
+Identify what changed in MCP since the November 2025 spec release and what should be represented in this workshop material, with routing guidance for the full 4-workshop series.
+
+## Scope + sources used
+
+- MCP spec releases from GitHub: `modelcontextprotocol/modelcontextprotocol` (starting with `2025-11-25`).
+- MCP spec changelog + docs for:
+  - `2025-11-25`
+  - previous baseline used by this workshop: `2025-06-18`
+- TypeScript SDK releases from GitHub: `modelcontextprotocol/typescript-sdk`, all tags from October 2025 onward (`1.19.0` through `v1.27.1`).
+- Current workshop code/docs in this repo.
+
+---
+
+## Current state of this workshop repo (baseline)
+
+### Version baseline in material
+
+- Content links are pinned to MCP spec `2025-06-18` across chapter docs.
+- Exercise packages are pinned to:
+  - `@modelcontextprotocol/sdk: ^1.24.3`
+  - `@modelcontextprotocol/inspector: ^0.17.5`
+
+### Concepts currently represented
+
+- Ping and lifecycle basics (stdio transport)
+- Tools
+- Resources + resource templates
+- Resources embedded/linked in tool outputs
+- Prompts
+- Completions (via schema completion helpers in examples)
+
+### Concepts not represented in this workshop today
+
+- Elicitation (form/url modes)
+- Sampling (including tool-enabled sampling)
+- Tasks (experimental long-running request model)
+- MCP auth/OAuth flows and remote transport hardening
+
+---
+
+## MCP spec changes since the November 2025 release
+
+### Release reality check
+
+- Since November 2025, the MCP spec has one stable release: `2025-11-25` (plus `2025-11-25-RC`).
+- No newer stable spec revision exists yet beyond `2025-11-25`.
+
+### Full delta assessment: added/removed/changed and workshop impact
+
+The `2025-11-25` changelog is the authoritative delta from `2025-06-18`.
+
+#### A) Directly affects this Fundamentals workshop (should be represented here)
+
+1. **Icons metadata added for tools/resources/resource templates/prompts** (added)
+   - New metadata can now be surfaced on all core server primitives this workshop teaches.
+   - Impact: high for conceptual completeness, low implementation complexity.
+   - Recommendation: add at least one worked example in each relevant chapter (tools, resources, prompts), while noting client support may vary.
+
+2. **Tool naming guidance formalized (SEP-986)** (changed)
+   - Naming guidance now explicitly recommends restricted character set/length and uniqueness constraints.
+   - Impact: medium. This workshop teaches tool naming heavily.
+   - Recommendation: add a concise naming rule box and a quick lint-like check in tests/docs. Current names (snake_case) are mostly compatible.
+
+3. **JSON Schema 2020-12 is now the default dialect** (changed)
+   - MCP now has explicit JSON Schema usage rules and default dialect behavior.
+   - Impact: medium. This workshop teaches tool schemas and prompt args.
+   - Recommendation: add a schema-dialect note; clarify when to set `$schema` explicitly and that no-arg tools should still use valid object schema.
+
+4. **Tool error handling guidance tightened** (changed)
+   - Spec clarifies input validation errors should be surfaced as tool execution errors (model-correctable), not generic protocol errors.
+   - Impact: medium/high. Error handling is an explicit exercise objective.
+   - Recommendation: refresh error-handling narrative and examples to match 2025-11 terminology and intent.
+
+5. **`Implementation.description` added** (added)
+   - Optional description now appears in initialization metadata.
+   - Impact: low, but a nice quality upgrade for introspection UIs.
+   - Recommendation: mention it in initialization examples as optional metadata.
+
+6. **stdio stderr clarification** (changed)
+   - Clarified that stdio servers may use stderr for general logging (not only errors).
+   - Impact: low. This workshop already logs startup messages to stderr.
+   - Recommendation: add a short note confirming this is spec-consistent.
+
+7. **Spec link/version anchor updates** (changed)
+   - All chapter links currently reference `2025-06-18`.
+   - Impact: high for learner trust and promised “updated workshop” deliverable.
+   - Recommendation: migrate all spec links to `2025-11-25`.
+
+#### B) Important MCP changes, but better routed to other workshops in the series
+
+1. **URL-mode elicitation + required URL elicitation error (`-32042`)** (added)
+2. **Elicitation schema updates (`EnumSchema` redesign, defaults on primitive types, single/multi-select support)** (changed)
+3. **Sampling now supports tools + `toolChoice` loop semantics** (added)
+4. **Experimental Tasks model for durable/async request handling** (added)
+5. **Auth/OAuth discovery and consent flow updates**
+   - OIDC discovery support
+   - RFC 9728 protected resource metadata alignment
+   - Incremental scope via `WWW-Authenticate`
+   - OAuth client metadata document support
+6. **Streamable HTTP/SSE polling + origin-handling clarifications** (changed)
+
+These are significant, but they are not core to this Fundamentals repo’s current scope.
+
+---
+
+## TypeScript SDK releases since October 2025 (significant changes)
+
+Reviewed all releases from `1.19.0` (2025-10-02) through `v1.27.1` (2026-02-24) via `gh`.
+
+### Most important changes to represent in workshop material
+
+1. **`1.22.0`**
+   - SEP-986 tool naming support
+   - SEP-1319 request payload/schema decoupling
+   - SEP-1034/1330 elicitation schema defaults and enum compatibility
+   - Why it matters: introduces key spec-alignment behavior that informs naming/schema guidance.
+
+2. **`1.23.0`**
+   - URL elicitation (SEP-1036)
+   - Sampling with tools (SEP-1577)
+   - JSON Schema 2020-12 support behavior (SEP-1613)
+   - Zod v4 compatibility (while keeping v3.25+ compatibility)
+   - Why it matters: foundational new concepts for Advanced workshop content and schema story.
+
+3. **`1.24.0`**
+   - Protocol alignment to `2025-11-25`
+   - Tasks support (SEP-1686)
+   - Why it matters: this is the first “spec-2025-11-25 aligned” release line.
+
+4. **`1.24.2`**
+   - Optional resource annotations support
+   - Why it matters: improves resource/tool UX metadata story (relevant to richer examples).
+
+5. **`1.25.0`**
+   - Stricter spec-compliance typing (removal of loose/passthrough shapes)
+   - Protocol date validation
+   - Why it matters: helps prevent teaching patterns that no longer type-check cleanly.
+
+6. **`v1.26.0`** (security-critical)
+   - Fix for cross-client response data leak advisory (GHSA-345p-7cg4-v4c7)
+   - Why it matters: should be your minimum safe baseline for refreshed workshops.
+
+7. **`v1.27.0` + `v1.27.1`**
+   - Task streaming methods for elicitation/sampling
+   - OAuth server discovery caching backport
+   - Additional security fix: command injection prevention in example URL opening
+   - Why it matters: better conformance and safer baseline.
+
+### Notable patch-line items to keep in mind
+
+- `1.23.1` / `1.24.3`: SSE priming/back-compat fixes.
+- `v1.25.2`: URI template ReDoS fix.
+- `v1.25.3`: sampling-with-tools validation fix.
+- `1.21.1` / `1.21.2`: auth discovery/scope regression fixes.
+
+### Practical baseline recommendation
+
+For updated 2026 workshop material, target **`@modelcontextprotocol/sdk >= v1.27.1`** to pick up the latest spec/backport/security fixes from this period.
+
+---
+
+## What’s missing in this Fundamentals workshop right now (concept gaps)
+
+These are gaps _within this repo_ that should be addressed to claim a credible 2025-11+ refresh:
+
+1. **Spec version references are stale** (`2025-06-18` links throughout docs).
+2. **No explicit treatment of tool naming constraints/guidance.**
+3. **No examples of icons metadata on tools/resources/prompts/templates.**
+4. **No explicit JSON Schema dialect guidance (2020-12 default behavior).**
+5. **Error-handling section should be refreshed to the newer “tool-execution vs protocol” framing language.**
+
+---
+
+## What to route to which workshop in the 4-workshop series
+
+_Assuming the series split is Fundamentals / Advanced MCP Features / Remote with Authentication / MCP-UI._
+
+### Keep in **Fundamentals** (this repo)
+
+- Core server primitives: tools/resources/prompts
+- Updated schema + naming conventions
+- Metadata quality upgrades (icons, basic annotations awareness)
+- Clear compatibility/versioning framing (2025-11-25 baseline)
+
+### Put in **Advanced MCP Features**
+
+- Sampling with tools (`tools`, `toolChoice`, tool loop constraints)
+- Elicitation deep dive (form/url modes, enum/default evolution)
+- Tasks (experimental long-running flow, polling/result retrieval)
+- Optional: richer structured outputs + advanced annotations patterns
+
+### Put in **Remote with Authentication**
+
+- OIDC discovery enhancements
+- Protected resource metadata + `.well-known` fallback behavior
+- Incremental scope consent and `WWW-Authenticate` patterns
+- OAuth client metadata docs and pre-registration flows
+- Client-credentials and remote transport auth patterns
+
+### Put in **MCP-UI**
+
+- How icons metadata should be surfaced in UX
+- How annotations (`audience`, `priority`, `lastModified`) inform UI behavior
+- Prompt/resource affordance design around richer metadata
+
+---
+
+## Proposed upgrade backlog (planning starter)
+
+## P0 — Immediate trust-restoring refresh (this repo)
+
+1. Update all spec links from `2025-06-18` to `2025-11-25`.
+2. Bump SDK baseline to `v1.27.1` (and align inspector version accordingly).
+3. Re-run exercise tests and adjust any typing/schema breakage from stricter SDK types.
+4. Add a short “protocol revision baseline” note at workshop intro.
+
+## P1 — Fundamentals concept alignment
+
+1. Add tool naming guidance callout (SEP-986 era guidance).
+2. Add icons metadata examples in:
+   - tools chapter,
+   - resources chapter (including template),
+   - prompts chapter.
+3. Add JSON Schema usage callout (default 2020-12, explicit `$schema` if needed).
+4. Update error-handling chapter wording/examples for 2025-11 semantics.
+
+## P2 — Cross-series coordination
+
+1. Build Advanced workshop modules for:
+   - sampling-with-tools,
+   - modern elicitation modes/schema,
+   - tasks.
+2. Build Remote Auth workshop updates for 2025-11 auth discovery/consent changes.
+3. Add MCP-UI guidance for metadata-driven UX (icons/annotations).
+
+---
+
+## Risks / notes
+
+- **Tasks are explicitly experimental** in spec `2025-11-25`; avoid over-promising stability in learner messaging.
+- **Client support is uneven** for some newer features; workshop copy should distinguish “spec-defined” vs “widely implemented in clients today.”
+- **Version drift risk** remains high if docs pin old spec URLs; treat link updates as mandatory, not optional polish.
+
+---
+
+## Appendix: release windows reviewed
+
+### Spec repo releases checked
+
+- `2025-11-25` (stable)
+- `2025-11-25-RC` (pre-release)
+- previous workshop baseline: `2025-06-18`
+
+### TypeScript SDK releases checked (Oct 2025 onward)
+
+- `1.19.0`
+- `1.20.0`, `1.20.1`, `1.20.2`
+- `1.21.0`, `1.21.1`, `1.21.2`
+- `1.22.0`
+- `1.23.0-beta.0`, `1.23.0`, `1.23.1`
+- `1.24.0`, `1.24.1`, `1.24.2`, `1.24.3`
+- `1.25.0`, `1.25.1`, `v1.25.2`, `v1.25.3`
+- `v1.26.0`
+- `v1.27.0`, `v1.27.1`

--- a/docs/upgrade-research.md
+++ b/docs/upgrade-research.md
@@ -302,11 +302,12 @@ way that invalidates current recorded walkthroughs.
 
 ### Breaking changes in the current recommended update direction
 
-1. **SDK baseline upgrade to current line (`@modelcontextprotocol/sdk v1.27.1`+)**
+1. **SDK baseline upgrade to current line
+   (`@modelcontextprotocol/sdk v1.27.1`+)**
    - Why this is breaking: stricter spec/type behavior in newer SDK versions can
      require edits to exercise step solutions and tests.
-   - Re-record impact: any lesson video that shows solution code or test behavior
-     affected by SDK alignment.
+   - Re-record impact: any lesson video that shows solution code or test
+     behavior affected by SDK alignment.
 
 2. **Add icons metadata examples to core primitives**
    - Why this is breaking: solution code must change where tools/resources/
@@ -330,8 +331,8 @@ way that invalidates current recorded walkthroughs.
 ### Not breaking (no re-record required by itself)
 
 - Spec URL/version link updates only.
-- Instruction wording/policy updates only (including "no backwards compatibility"
-  posture text).
+- Instruction wording/policy updates only (including "no backwards
+  compatibility" posture text).
 - Draft watchlist and planning notes that do not alter exercise code.
 
 ---

--- a/docs/upgrade-research.md
+++ b/docs/upgrade-research.md
@@ -8,6 +8,14 @@ Identify what changed in MCP since the November 2025 spec release and what
 should be represented in this workshop material, with routing guidance for the
 full 4-workshop series.
 
+## Update posture for this refresh (explicit)
+
+- We **do not care about backwards compatibility** for this workshop refresh.
+- We will teach MCP as it exists **currently** (stable spec `2025-11-25`, latest
+  stable TypeScript SDK line).
+- We will remove or avoid “legacy compatibility” teaching paths unless they are
+  explicitly called out as historical context.
+
 ## Scope + sources used
 
 - MCP spec releases from GitHub: `modelcontextprotocol/modelcontextprotocol`
@@ -188,6 +196,52 @@ For updated 2026 workshop material, target
 **`@modelcontextprotocol/sdk >= v1.27.1`** to pick up the latest
 spec/backport/security fixes from this period.
 
+Given the “no backwards compatibility” posture, teach one baseline only:
+
+1. Spec references pinned to `2025-11-25`
+2. SDK examples based on `v1.27.1`+ behavior
+3. No special guidance for old protocol revisions/legacy clients in core
+   exercises
+
+---
+
+## Draft spec watchlist (if draft became stable next week)
+
+Current draft changelog vs `2025-11-25` is small but non-zero.
+
+### Draft item 1: `extensions` in client/server capabilities
+
+- Draft adds an `extensions` field to both `ClientCapabilities` and
+  `ServerCapabilities`.
+- Likely impact on this workshop if draft ships soon:
+  - Update lifecycle/capabilities teaching to include optional extension
+    negotiation.
+  - Ensure examples/tests do not assume a fully-closed capabilities object shape.
+- Preemptive action now:
+  - Add one short note + snippet in the intro/lifecycle material showing
+    `capabilities.extensions` as optional and forward-compatible.
+
+### Draft item 2: OpenTelemetry trace context conventions in `_meta`
+
+- Draft documents `_meta` key conventions for `traceparent`, `tracestate`, and
+  `baggage`.
+- Likely impact on this workshop if draft ships soon:
+  - Mostly documentation-level for Fundamentals; implementation depth belongs
+    more in advanced/production topics.
+  - Still useful to teach that `_meta` may carry tracing context and should not
+    be stripped accidentally.
+- Preemptive action now:
+  - Add a brief “_meta is reserved and may include trace context” callout in
+    lifecycle/protocol fundamentals.
+
+### Draft risk level summary
+
+- **Risk level:** Low-to-medium for Fundamentals.
+- **Why:** No major feature shifts in draft changelog; changes are additive and
+  mostly around negotiation/observability conventions.
+- **One-week hedge:** include the two preemptive notes above now so a near-term
+  release does not force structural lesson rewrites.
+
 ---
 
 ## What’s missing in this Fundamentals workshop right now (concept gaps)
@@ -239,36 +293,44 @@ Authentication / MCP-UI._
 
 ---
 
-## Proposed upgrade backlog (planning starter)
+## Recommended actions to take (clear checklist)
 
-## P0 — Immediate trust-restoring refresh (this repo)
+### 1) Lock decisions now (non-negotiable)
+
+1. Confirm and publish the policy: **no backwards compatibility support in core
+   workshop content**.
+2. Teach against one baseline only:
+   - spec `2025-11-25`
+   - SDK `v1.27.1`+.
+3. Remove stale links and legacy-version framing from learner-facing docs.
+
+### 2) Ship the Fundamentals refresh immediately (this repo)
 
 1. Update all spec links from `2025-06-18` to `2025-11-25`.
-2. Bump SDK baseline to `v1.27.1` (and align inspector version accordingly).
-3. Re-run exercise tests and adjust any typing/schema breakage from stricter SDK
-   types.
-4. Add a short “protocol revision baseline” note at workshop intro.
+2. Bump exercise dependencies to `@modelcontextprotocol/sdk` latest stable
+   (`v1.27.1` or newer) and align inspector accordingly.
+3. Re-run exercise tests and fix any typing/schema strictness issues.
+4. Add/update lesson content for:
+   - tool naming guidance,
+   - icons metadata on tools/resources/prompts/templates,
+   - JSON Schema 2020-12 default-dialect behavior,
+   - tool execution vs protocol error handling language.
 
-## P1 — Fundamentals concept alignment
+### 3) Add one-week draft hedge changes now
 
-1. Add tool naming guidance callout (SEP-986 era guidance).
-2. Add icons metadata examples in:
-   - tools chapter,
-   - resources chapter (including template),
-   - prompts chapter.
-3. Add JSON Schema usage callout (default 2020-12, explicit `$schema` if
-   needed).
-4. Update error-handling chapter wording/examples for 2025-11 semantics.
+1. Add a short lifecycle note/snippet for optional
+   `capabilities.extensions`.
+2. Add a short protocol note that `_meta` may carry trace context keys
+   (`traceparent`, `tracestate`, `baggage`).
+3. Keep these as lightweight notes so if draft becomes stable quickly, this
+   workshop remains current with minimal additional edits.
 
-## P2 — Cross-series coordination
+### 4) Parallel cross-workshop updates (series-level)
 
-1. Build Advanced workshop modules for:
-   - sampling-with-tools,
-   - modern elicitation modes/schema,
-   - tasks.
-2. Build Remote Auth workshop updates for 2025-11 auth discovery/consent
-   changes.
-3. Add MCP-UI guidance for metadata-driven UX (icons/annotations).
+1. **Advanced MCP Features:** sampling-with-tools, elicitation updates, tasks.
+2. **Remote with Authentication:** OIDC discovery, incremental scopes, protected
+   resource metadata behavior, OAuth metadata docs.
+3. **MCP-UI:** practical UX use of icons + annotations.
 
 ---
 
@@ -276,8 +338,11 @@ Authentication / MCP-UI._
 
 - **Tasks are explicitly experimental** in spec `2025-11-25`; avoid
   over-promising stability in learner messaging.
+- Because we are intentionally dropping backwards compatibility, older MCP
+  clients may not align with taught behavior; this is an accepted tradeoff for
+  this refresh.
 - **Client support is uneven** for some newer features; workshop copy should
-  distinguish “spec-defined” vs “widely implemented in clients today.”
+  still distinguish “spec-defined” vs “widely implemented in clients today.”
 - **Version drift risk** remains high if docs pin old spec URLs; treat link
   updates as mandatory, not optional polish.
 

--- a/docs/upgrade-research.md
+++ b/docs/upgrade-research.md
@@ -4,15 +4,19 @@ _Last updated: 2026-02-26_
 
 ## Goal
 
-Identify what changed in MCP since the November 2025 spec release and what should be represented in this workshop material, with routing guidance for the full 4-workshop series.
+Identify what changed in MCP since the November 2025 spec release and what
+should be represented in this workshop material, with routing guidance for the
+full 4-workshop series.
 
 ## Scope + sources used
 
-- MCP spec releases from GitHub: `modelcontextprotocol/modelcontextprotocol` (starting with `2025-11-25`).
+- MCP spec releases from GitHub: `modelcontextprotocol/modelcontextprotocol`
+  (starting with `2025-11-25`).
 - MCP spec changelog + docs for:
   - `2025-11-25`
   - previous baseline used by this workshop: `2025-06-18`
-- TypeScript SDK releases from GitHub: `modelcontextprotocol/typescript-sdk`, all tags from October 2025 onward (`1.19.0` through `v1.27.1`).
+- TypeScript SDK releases from GitHub: `modelcontextprotocol/typescript-sdk`,
+  all tags from October 2025 onward (`1.19.0` through `v1.27.1`).
 - Current workshop code/docs in this repo.
 
 ---
@@ -48,7 +52,8 @@ Identify what changed in MCP since the November 2025 spec release and what shoul
 
 ### Release reality check
 
-- Since November 2025, the MCP spec has one stable release: `2025-11-25` (plus `2025-11-25-RC`).
+- Since November 2025, the MCP spec has one stable release: `2025-11-25` (plus
+  `2025-11-25-RC`).
 - No newer stable spec revision exists yet beyond `2025-11-25`.
 
 ### Full delta assessment: added/removed/changed and workshop impact
@@ -57,25 +62,33 @@ The `2025-11-25` changelog is the authoritative delta from `2025-06-18`.
 
 #### A) Directly affects this Fundamentals workshop (should be represented here)
 
-1. **Icons metadata added for tools/resources/resource templates/prompts** (added)
-   - New metadata can now be surfaced on all core server primitives this workshop teaches.
+1. **Icons metadata added for tools/resources/resource templates/prompts**
+   (added)
+   - New metadata can now be surfaced on all core server primitives this
+     workshop teaches.
    - Impact: high for conceptual completeness, low implementation complexity.
-   - Recommendation: add at least one worked example in each relevant chapter (tools, resources, prompts), while noting client support may vary.
+   - Recommendation: add at least one worked example in each relevant chapter
+     (tools, resources, prompts), while noting client support may vary.
 
 2. **Tool naming guidance formalized (SEP-986)** (changed)
-   - Naming guidance now explicitly recommends restricted character set/length and uniqueness constraints.
+   - Naming guidance now explicitly recommends restricted character set/length
+     and uniqueness constraints.
    - Impact: medium. This workshop teaches tool naming heavily.
-   - Recommendation: add a concise naming rule box and a quick lint-like check in tests/docs. Current names (snake_case) are mostly compatible.
+   - Recommendation: add a concise naming rule box and a quick lint-like check
+     in tests/docs. Current names (snake_case) are mostly compatible.
 
 3. **JSON Schema 2020-12 is now the default dialect** (changed)
    - MCP now has explicit JSON Schema usage rules and default dialect behavior.
    - Impact: medium. This workshop teaches tool schemas and prompt args.
-   - Recommendation: add a schema-dialect note; clarify when to set `$schema` explicitly and that no-arg tools should still use valid object schema.
+   - Recommendation: add a schema-dialect note; clarify when to set `$schema`
+     explicitly and that no-arg tools should still use valid object schema.
 
 4. **Tool error handling guidance tightened** (changed)
-   - Spec clarifies input validation errors should be surfaced as tool execution errors (model-correctable), not generic protocol errors.
+   - Spec clarifies input validation errors should be surfaced as tool execution
+     errors (model-correctable), not generic protocol errors.
    - Impact: medium/high. Error handling is an explicit exercise objective.
-   - Recommendation: refresh error-handling narrative and examples to match 2025-11 terminology and intent.
+   - Recommendation: refresh error-handling narrative and examples to match
+     2025-11 terminology and intent.
 
 5. **`Implementation.description` added** (added)
    - Optional description now appears in initialization metadata.
@@ -83,7 +96,8 @@ The `2025-11-25` changelog is the authoritative delta from `2025-06-18`.
    - Recommendation: mention it in initialization examples as optional metadata.
 
 6. **stdio stderr clarification** (changed)
-   - Clarified that stdio servers may use stderr for general logging (not only errors).
+   - Clarified that stdio servers may use stderr for general logging (not only
+     errors).
    - Impact: low. This workshop already logs startup messages to stderr.
    - Recommendation: add a short note confirming this is spec-consistent.
 
@@ -95,7 +109,8 @@ The `2025-11-25` changelog is the authoritative delta from `2025-06-18`.
 #### B) Important MCP changes, but better routed to other workshops in the series
 
 1. **URL-mode elicitation + required URL elicitation error (`-32042`)** (added)
-2. **Elicitation schema updates (`EnumSchema` redesign, defaults on primitive types, single/multi-select support)** (changed)
+2. **Elicitation schema updates (`EnumSchema` redesign, defaults on primitive
+   types, single/multi-select support)** (changed)
 3. **Sampling now supports tools + `toolChoice` loop semantics** (added)
 4. **Experimental Tasks model for durable/async request handling** (added)
 5. **Auth/OAuth discovery and consent flow updates**
@@ -105,13 +120,15 @@ The `2025-11-25` changelog is the authoritative delta from `2025-06-18`.
    - OAuth client metadata document support
 6. **Streamable HTTP/SSE polling + origin-handling clarifications** (changed)
 
-These are significant, but they are not core to this Fundamentals repo’s current scope.
+These are significant, but they are not core to this Fundamentals repo’s current
+scope.
 
 ---
 
 ## TypeScript SDK releases since October 2025 (significant changes)
 
-Reviewed all releases from `1.19.0` (2025-10-02) through `v1.27.1` (2026-02-24) via `gh`.
+Reviewed all releases from `1.19.0` (2025-10-02) through `v1.27.1` (2026-02-24)
+via `gh`.
 
 ### Most important changes to represent in workshop material
 
@@ -119,14 +136,16 @@ Reviewed all releases from `1.19.0` (2025-10-02) through `v1.27.1` (2026-02-24) 
    - SEP-986 tool naming support
    - SEP-1319 request payload/schema decoupling
    - SEP-1034/1330 elicitation schema defaults and enum compatibility
-   - Why it matters: introduces key spec-alignment behavior that informs naming/schema guidance.
+   - Why it matters: introduces key spec-alignment behavior that informs
+     naming/schema guidance.
 
 2. **`1.23.0`**
    - URL elicitation (SEP-1036)
    - Sampling with tools (SEP-1577)
    - JSON Schema 2020-12 support behavior (SEP-1613)
    - Zod v4 compatibility (while keeping v3.25+ compatibility)
-   - Why it matters: foundational new concepts for Advanced workshop content and schema story.
+   - Why it matters: foundational new concepts for Advanced workshop content and
+     schema story.
 
 3. **`1.24.0`**
    - Protocol alignment to `2025-11-25`
@@ -135,21 +154,25 @@ Reviewed all releases from `1.19.0` (2025-10-02) through `v1.27.1` (2026-02-24) 
 
 4. **`1.24.2`**
    - Optional resource annotations support
-   - Why it matters: improves resource/tool UX metadata story (relevant to richer examples).
+   - Why it matters: improves resource/tool UX metadata story (relevant to
+     richer examples).
 
 5. **`1.25.0`**
    - Stricter spec-compliance typing (removal of loose/passthrough shapes)
    - Protocol date validation
-   - Why it matters: helps prevent teaching patterns that no longer type-check cleanly.
+   - Why it matters: helps prevent teaching patterns that no longer type-check
+     cleanly.
 
 6. **`v1.26.0`** (security-critical)
    - Fix for cross-client response data leak advisory (GHSA-345p-7cg4-v4c7)
-   - Why it matters: should be your minimum safe baseline for refreshed workshops.
+   - Why it matters: should be your minimum safe baseline for refreshed
+     workshops.
 
 7. **`v1.27.0` + `v1.27.1`**
    - Task streaming methods for elicitation/sampling
    - OAuth server discovery caching backport
-   - Additional security fix: command injection prevention in example URL opening
+   - Additional security fix: command injection prevention in example URL
+     opening
    - Why it matters: better conformance and safer baseline.
 
 ### Notable patch-line items to keep in mind
@@ -161,25 +184,30 @@ Reviewed all releases from `1.19.0` (2025-10-02) through `v1.27.1` (2026-02-24) 
 
 ### Practical baseline recommendation
 
-For updated 2026 workshop material, target **`@modelcontextprotocol/sdk >= v1.27.1`** to pick up the latest spec/backport/security fixes from this period.
+For updated 2026 workshop material, target
+**`@modelcontextprotocol/sdk >= v1.27.1`** to pick up the latest
+spec/backport/security fixes from this period.
 
 ---
 
 ## What’s missing in this Fundamentals workshop right now (concept gaps)
 
-These are gaps _within this repo_ that should be addressed to claim a credible 2025-11+ refresh:
+These are gaps _within this repo_ that should be addressed to claim a credible
+2025-11+ refresh:
 
 1. **Spec version references are stale** (`2025-06-18` links throughout docs).
 2. **No explicit treatment of tool naming constraints/guidance.**
 3. **No examples of icons metadata on tools/resources/prompts/templates.**
 4. **No explicit JSON Schema dialect guidance (2020-12 default behavior).**
-5. **Error-handling section should be refreshed to the newer “tool-execution vs protocol” framing language.**
+5. **Error-handling section should be refreshed to the newer “tool-execution vs
+   protocol” framing language.**
 
 ---
 
 ## What to route to which workshop in the 4-workshop series
 
-_Assuming the series split is Fundamentals / Advanced MCP Features / Remote with Authentication / MCP-UI._
+_Assuming the series split is Fundamentals / Advanced MCP Features / Remote with
+Authentication / MCP-UI._
 
 ### Keep in **Fundamentals** (this repo)
 
@@ -217,7 +245,8 @@ _Assuming the series split is Fundamentals / Advanced MCP Features / Remote with
 
 1. Update all spec links from `2025-06-18` to `2025-11-25`.
 2. Bump SDK baseline to `v1.27.1` (and align inspector version accordingly).
-3. Re-run exercise tests and adjust any typing/schema breakage from stricter SDK types.
+3. Re-run exercise tests and adjust any typing/schema breakage from stricter SDK
+   types.
 4. Add a short “protocol revision baseline” note at workshop intro.
 
 ## P1 — Fundamentals concept alignment
@@ -227,7 +256,8 @@ _Assuming the series split is Fundamentals / Advanced MCP Features / Remote with
    - tools chapter,
    - resources chapter (including template),
    - prompts chapter.
-3. Add JSON Schema usage callout (default 2020-12, explicit `$schema` if needed).
+3. Add JSON Schema usage callout (default 2020-12, explicit `$schema` if
+   needed).
 4. Update error-handling chapter wording/examples for 2025-11 semantics.
 
 ## P2 — Cross-series coordination
@@ -236,16 +266,20 @@ _Assuming the series split is Fundamentals / Advanced MCP Features / Remote with
    - sampling-with-tools,
    - modern elicitation modes/schema,
    - tasks.
-2. Build Remote Auth workshop updates for 2025-11 auth discovery/consent changes.
+2. Build Remote Auth workshop updates for 2025-11 auth discovery/consent
+   changes.
 3. Add MCP-UI guidance for metadata-driven UX (icons/annotations).
 
 ---
 
 ## Risks / notes
 
-- **Tasks are explicitly experimental** in spec `2025-11-25`; avoid over-promising stability in learner messaging.
-- **Client support is uneven** for some newer features; workshop copy should distinguish “spec-defined” vs “widely implemented in clients today.”
-- **Version drift risk** remains high if docs pin old spec URLs; treat link updates as mandatory, not optional polish.
+- **Tasks are explicitly experimental** in spec `2025-11-25`; avoid
+  over-promising stability in learner messaging.
+- **Client support is uneven** for some newer features; workshop copy should
+  distinguish “spec-defined” vs “widely implemented in clients today.”
+- **Version drift risk** remains high if docs pin old spec URLs; treat link
+  updates as mandatory, not optional polish.
 
 ---
 


### PR DESCRIPTION
Add `docs/upgrade-research.md` to outline the plan for updating the workshop to the latest MCP spec and SDK.

---
<p><a href="https://cursor.com/agents/bc-f7e9b2e0-1a29-46ee-a7ec-5be598d86105"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f7e9b2e0-1a29-46ee-a7ec-5be598d86105"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

